### PR TITLE
fix typo in iptables_add

### DIFF
--- a/trevorproxy/lib/ssh.py
+++ b/trevorproxy/lib/ssh.py
@@ -153,7 +153,7 @@ class IPTables:
 
                 self.iptables_rules.append(iptables_main)
 
-                cmd = siptables_add + iptables_main
+                cmd = iptables_add + iptables_main
                 sudo_run(cmd)
 
 


### PR DESCRIPTION
the typo in this variable is causing script execution to fail


`[ERROR] Unhandled error (-v to debug): name 'siptables_add' is not defined`
